### PR TITLE
fix: 9 is the default codepage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ const controlChar = "^";
 
 const codepages = {
   /** Default codepage */
-  "8": "CP1252",
+  "9": "CP1252",
 
   /** Latin 1 */
   L: "CP1252",
@@ -54,7 +54,7 @@ const specials: Record<string, string> = {
 const isMultiByte = (codepage: Codepage, character: number): boolean => {
   switch (codepage) {
     case "L":
-    case "8":
+    case "9":
     case "G":
     case "C":
     case "E":


### PR DESCRIPTION
Somehow I've also implemented ^8 as the default codepage and colour in insim.rs, but looking at the wiki[1], that's not the case, and hasn't been for a number of years.

But I'm not sure where *I* got ^8 from either, after trawling the forum and the wiki.. seems unlikely that we both screwed up independently? 

[1] https://en.lfsmanual.net/wiki/LFS_Programming#LFS_strings_and_escape_codes